### PR TITLE
add get_size endpoint to get the canvas size

### DIFF
--- a/pixels/pixels.py
+++ b/pixels/pixels.py
@@ -327,7 +327,6 @@ async def authorize() -> Response:
 @app.get("/get_size")
 async def get_size(request: Request) -> dict:
     """Get the size of the pixels canvas."""
-
     return dict(width=constants.width, height=constants.height)
 
 


### PR DESCRIPTION
`GET /get_size` now returns an object like:
```json
{
  "width": 160,
  "height": 90
}
```

Reasoning:
- Makes writing code like constructing a PIL image from the get_pixels data possible.
- Enabled client side validation that valid pixels are being set without ever making API requests which will fail for that reason.