### PR TITLE
Namespace the canvas cache based on git_sha

### DIFF
--- a/pixels/canvas.py
+++ b/pixels/canvas.py
@@ -47,7 +47,7 @@ class Canvas:
             position = record["y"] * constants.width + record["x"]
             cache[position * 3:(position + 1) * 3] = bytes.fromhex(record["rgb"])
 
-        await self.redis.set("canvas-cache", cache)
+        await self.redis.set(f"{constants.git_sha}-canvas-cache", cache)
 
         log.info(f"Cache updated finished! (took {time() - start_time}s)")
         await conn.execute("UPDATE cache_state SET last_synced = now()")
@@ -122,15 +122,15 @@ class Canvas:
 
             # Update the cache
             position = (y * constants.width + x) * 3
-            await self.redis.setrange("canvas-cache", position, bytes.fromhex(rgb))
+            await self.redis.setrange(f"{constants.git_sha}-canvas-cache", position, bytes.fromhex(rgb))
 
             await conn.execute("UPDATE cache_state SET last_synced = now()")
 
     async def get_pixels(self) -> bytearray:
         """Returns the whole board."""
-        return await self.redis.get("canvas-cache")
+        return await self.redis.get(f"{constants.git_sha}-canvas-cache")
 
     async def get_pixel(self, x: int, y: int) -> bytearray:
         """Returns a single pixel from the board."""
         position = (y * constants.width + x) * 3
-        return await self.redis.getrange("canvas-cache", position, position+2)
+        return await self.redis.getrange(f"{constants.git_sha}-canvas-cache", position, position+2)

--- a/pixels/constants.py
+++ b/pixels/constants.py
@@ -21,6 +21,8 @@ user_url = config("USER_URL", default="https://discord.com/api/users/@me")
 api_base = "https://discord.com/api/v8"
 webhook_url = config("WEBHOOK_URL")
 
+git_sha = config("GIT_SHA")
+
 # 16:9 is the aspect ratio of a guild banner
 base_width = 16
 base_height = 9


### PR DESCRIPTION
This ensures that old versions of the project don't attempt to use possibly incompatible version of the canvas cache. 

However, this could lead to hanging versions of the cache due to how we deal with redis persistence.