### PR TITLE
Prep for shrink

### DIFF
--- a/pixels/canvas.py
+++ b/pixels/canvas.py
@@ -42,7 +42,13 @@ class Canvas:
 
         cache = bytearray(constants.width * constants.height * 3)
 
-        records = await conn.fetch("SELECT x, y, rgb FROM current_pixel")
+        sql = (
+            "SELECT x, y, rgb "
+            "FROM current_pixel "
+            "WHERE x < $1 "
+            "AND y < $2"
+        )
+        records = await conn.fetch(sql, constants.width, constants.height)
         for record in records:
             position = record["y"] * constants.width + record["x"]
             cache[position * 3:(position + 1) * 3] = bytes.fromhex(record["rgb"])

--- a/pixels/constants.py
+++ b/pixels/constants.py
@@ -21,17 +21,13 @@ user_url = config("USER_URL", default="https://discord.com/api/users/@me")
 api_base = "https://discord.com/api/v8"
 webhook_url = config("WEBHOOK_URL")
 
-# 16:9 is the aspect ratio of a guild banner
-base_width = 16
-base_height = 9
-
 # For ease of scaling
 mutliplyer = 15
-width = base_width * mutliplyer
-height = base_height * mutliplyer
+width = 16 * mutliplyer
+height = 9 * mutliplyer
 
 # We want to push a larger image to Discord for visibility
-webhook_size = (base_width * 100, base_height * 100)
+webhook_size = (1600, 900)
 
 x_query_validator = Query(None, ge=0, lt=width)
 y_query_validator = Query(None, ge=0, lt=height)


### PR DESCRIPTION
Currently the cache refresh breaks if we decrease either the width or the height below what the biggest x or y coordinate is. This fixes that by only fetching pixels within the width and height defined.