### PR TITLE
Skip canvas valid check on ban

### DIFF
--- a/pixels/pixels.py
+++ b/pixels/pixels.py
@@ -340,7 +340,7 @@ async def ban_users(request: Request, user_list: t.List[User]) -> ModBan:
     sql = "UPDATE pixel_history SET deleted=TRUE where user_id=any($1::bigint[])"
     await conn.execute(sql, db_users)
 
-    await canvas.sync_cache(conn)
+    await canvas.sync_cache(conn, skip_check=True)
 
     resp = {"banned": db_users, "not_found": []}
     if non_db_users:


### PR DESCRIPTION
When banning someone previously, if another edit came in after the pixel_history
is marked as deleted, the cache state would be set as up to date, so when the
sync_cache() call was ran, it wouldn't refresh the cache.

This commit adds a kwarg to froce a cache refresh when needed.