### PR TITLE
Start refreshing refresh tokens

### DIFF
--- a/pixels/constants.py
+++ b/pixels/constants.py
@@ -38,9 +38,10 @@ class Discord:
 
 
 class Authorization:
-    """Configuration regarding the access token authorization."""
+    """Configuration regarding the token authorization."""
 
-    EXPIRES_IN = 3600
+    ACCESS_EXPIRES_IN = 3600
+    REFRESH_EXPIRES_IN = ACCESS_EXPIRES_IN * 6  # 6 access token lifetimes
 
 
 class Server:

--- a/pixels/utils/auth.py
+++ b/pixels/utils/auth.py
@@ -2,7 +2,7 @@ import logging
 import secrets
 from datetime import datetime, timedelta, timezone
 
-from asyncpg import Connection
+from asyncpg import Connection, Record
 from fastapi import HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
@@ -53,11 +53,14 @@ class JWTBearer(HTTPBearer):
         return credentials
 
 
-async def reset_user_token(conn: Connection, user_id: str) -> str:
+async def reset_user_token(conn: Connection, user_id: str) -> tuple[str, Record]:
     """
     Ensure a user exists and create a new token for them.
 
     If the user already exists, their token is regenerated and the old is invalidated.
+    This function returns the new refresh token, as well as the new row in the database.
+    By returning the new row an extra database call can be skipped when generating
+    access tokens. For most uses this can ignored.
     """
     # Returns None if the user doesn't exist and false if they aren't banned
     is_banned = await conn.fetchval("SELECT is_banned FROM users WHERE user_id = $1", int(user_id))
@@ -67,53 +70,71 @@ async def reset_user_token(conn: Connection, user_id: str) -> str:
     token_salt = secrets.token_urlsafe(16)
     is_mod = user_id in Server.MODS
 
-    await conn.execute(
+    row = await conn.fetchrow(
         "INSERT INTO users (user_id, key_salt, is_mod) "
         "VALUES ($1, $2, $3) "
-        "ON CONFLICT (user_id) DO UPDATE SET key_salt=$2",
+        "ON CONFLICT (user_id) DO UPDATE SET key_salt=$2 "
+        "RETURNING *",
         int(user_id),
         token_salt,
         is_mod,
     )
-    return jwt.encode(
+
+    # Refresh tokens don't expire automatically, but when a request to
+    # renew an access token is made and this timestamp has passed the refresh
+    # token will be reset. The new token is then returned for the user to
+    # replace locally.
+    expiration = datetime.now(timezone.utc) + timedelta(seconds=Authorization.REFRESH_EXPIRES_IN)
+    token = jwt.encode(
         {
             "id": user_id,
             "grant_type": "authorization_code",
+            "expiration": expiration.timestamp(),
             "salt": token_salt
         },
         Server.JWT_SECRET,
         algorithm="HS256"
     )
+    return token, row
 
 
-async def generate_access_token(conn: Connection, refresh_token: str) -> str:
+async def generate_access_token(conn: Connection, refresh_token: str) -> tuple[str, str]:
     """
     Generate a new access token for a user from its refresh token.
 
     This does not invalidate the old access token, rather it only generates a new
-    access token with a newer `expiration` field.
+    access token with a newer `expiration` field. That is unless the refresh
+    token used hasn't expired, in which case it will be reset and the old access
+    token will no longer work because the salt has changed.
+
+    This function returns the new access token and a potentially new refresh token.
     """
     try:
         token_data = jwt.decode(refresh_token, Server.JWT_SECRET)
     except JWTError:
         raise HTTPException(status_code=403, detail=AuthState.INVALID_TOKEN.value)
 
-    is_banned, key_salt = await conn.fetchrow(
-        "SELECT is_banned, key_salt FROM users WHERE user_id = $1", int(token_data["id"])
+    row = await conn.fetchrow(
+        "SELECT is_banned, user_id, key_salt FROM users WHERE user_id = $1", int(token_data["id"])
     )
-    if is_banned:
+    if row['is_banned']:
         raise PermissionError
-    elif key_salt != token_data["salt"]:
+    elif row['key_salt'] != token_data["salt"]:
         raise HTTPException(status_code=403, detail=AuthState.INVALID_TOKEN.value)
 
-    expiration = datetime.now(timezone.utc) + timedelta(seconds=Authorization.EXPIRES_IN)
-    return jwt.encode(
+    if int(token_data["expiration"]) < datetime.now(timezone.utc).timestamp():
+        # Time to renew the refresh token
+        refresh_token, row = await reset_user_token(conn, row['user_id'])
+
+    expiration = datetime.now(timezone.utc) + timedelta(seconds=Authorization.ACCESS_EXPIRES_IN)
+    token = jwt.encode(
         {
             "id": token_data["id"],
             "grant_type": "refresh_token",
             "expiration": expiration.timestamp(),
-            "salt": key_salt
+            "salt": row['key_salt']
         },
         Server.JWT_SECRET,
         algorithm="HS256"
     )
+    return token, refresh_token


### PR DESCRIPTION
This pull request means that refresh tokes now refresh when generating new access tokens.

Currently I have set the lifetime of a refresh token to be the lifetime of 6 access tokens (6 hours). This means that 6 hours after a refresh token has been generated, it will be refresh when trying to generate a new access token. When this happens the old is invalidated, but this is not done automatically. So you can wait several days, and the refresh token won't be invalidated until you try to generate an access token to use.