### PR TITLE
Pin platform in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.5-slim
+FROM --platform=linux/amd64 python:3.9-slim
 
 # Set pip to have no saved cache
 ENV PIP_NO_CACHE_DIR=false \


### PR DESCRIPTION
Some of our deps don't have wheels for atm processors.

With Mac's M1 chips becomming more common, we should make it easier for those users to build our environments.