### PR TITLE
`REPO_TOKEN` is no more.

### DIFF
--- a/.github/build.yaml
+++ b/.github/build.yaml
@@ -80,7 +80,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: python-discord/kubernetes
-          token: ${{ secrets.REPO_TOKEN }}
           path: kubernetes
 
       - name: Authenticate with Kubernetes


### PR DESCRIPTION
Solves part of https://github.com/python-discord/kubernetes/issues/140, since the repository is now public.